### PR TITLE
Programmatic Navigation to hidden More Tab

### DIFF
--- a/Sources/ExpandedTabBar/ExpandedTabBarController.swift
+++ b/Sources/ExpandedTabBar/ExpandedTabBarController.swift
@@ -24,7 +24,7 @@ let kMoreStackAtIndex = "_UIExpandedTabBarMoreStackAt"
 open class ExpandedTabBarController: UITabBarController {
 
     // MARK: - ViewControllers
-    private(set) var moreViewControllers: [UIViewController]?
+    public(set) var moreViewControllers: [UIViewController]?
 
     // MARK: - Public Variables
     public weak var expandedDelegate: ExpandedTabBarControllerDelegate?

--- a/Sources/ExpandedTabBar/ExpandedTabBarController.swift
+++ b/Sources/ExpandedTabBar/ExpandedTabBarController.swift
@@ -24,7 +24,7 @@ let kMoreStackAtIndex = "_UIExpandedTabBarMoreStackAt"
 open class ExpandedTabBarController: UITabBarController {
 
     // MARK: - ViewControllers
-    public(set) var moreViewControllers: [UIViewController]?
+    public var moreViewControllers: [UIViewController]?
 
     // MARK: - Public Variables
     public weak var expandedDelegate: ExpandedTabBarControllerDelegate?

--- a/Sources/ExpandedTabBar/ExpandedTabBarControllerDelegate.swift
+++ b/Sources/ExpandedTabBar/ExpandedTabBarControllerDelegate.swift
@@ -35,7 +35,10 @@ internal extension ExpandedTabBarController {
 
     @objc func itemTapped(_ sender: UITapGestureRecognizer) {
         guard let selectedViewController = moreViewControllers.selectedViewController(from: sender) else { return }
-        
+        itemTapped(selectedViewController)
+    }
+    
+    @objc func itemTapped(_ selectedViewController: UIViewController) {
         hideMoreContainer()
 
         guard let index = viewControllers.initialMoreIndex ?? viewControllers.selectedMoreIndex else { return }

--- a/Sources/ExpandedTabBar/ExpandedTabBarControllerDelegate.swift
+++ b/Sources/ExpandedTabBar/ExpandedTabBarControllerDelegate.swift
@@ -35,10 +35,10 @@ internal extension ExpandedTabBarController {
 
     @objc func itemTapped(_ sender: UITapGestureRecognizer) {
         guard let selectedViewController = moreViewControllers.selectedViewController(from: sender) else { return }
-        itemTapped(selectedViewController)
+        changeViewController(selectedViewController)
     }
     
-    @objc func itemTapped(_ selectedViewController: UIViewController) {
+    @objc func changeViewController(_ selectedViewController: UIViewController) {
         hideMoreContainer()
 
         guard let index = viewControllers.initialMoreIndex ?? viewControllers.selectedMoreIndex else { return }

--- a/Sources/ExpandedTabBar/ExpandedTabBarControllerDelegate.swift
+++ b/Sources/ExpandedTabBar/ExpandedTabBarControllerDelegate.swift
@@ -31,7 +31,7 @@ extension ExpandedTabBarController: UITabBarControllerDelegate {
     }
 }
 
-internal extension ExpandedTabBarController {
+public extension ExpandedTabBarController {
 
     @objc func itemTapped(_ sender: UITapGestureRecognizer) {
         guard let selectedViewController = moreViewControllers.selectedViewController(from: sender) else { return }


### PR DESCRIPTION
I needed to navigate to a hidden viewcontroller inside more view programmatically.

Had to change visibility of the moreViewControllers variable to public and create a public wrapper function of the itemTapped function.

With these changes i could now navigate programmatically like this from anywhere to any hidden moreTab via index :
`changeViewController(moreViewControllers![index])`

i thought some other users might need this functionality aswell ^^
anyways thanks for the good work

undeaDD

----

PS:

Beware my solution is hacky and force unwrap should not be used ... just for easy understanding ^^
maybe introduce a helper function that doesnt need moreViewControllers to be public ?
thats left for you to figure out though ^^ 

